### PR TITLE
Return full chain result from get_response

### DIFF
--- a/src/chatbot/bot.py
+++ b/src/chatbot/bot.py
@@ -44,8 +44,7 @@ def get_response(query, chain):
     """
     Gets a response from the QA chain for a given query.
     """
-    result = chain({'query': query})
-    return result['result']
+    return chain({'query': query})
 
 if __name__ == "__main__":
     qa_chain = create_qa_chain()
@@ -53,8 +52,8 @@ if __name__ == "__main__":
     question = "I want to operate under a fictitious business name"
     print(f"\nQuery: {question}")
 
-    response = get_response(question, qa_chain)
-    print(f"Answer: {response}")
+    result = get_response(question, qa_chain)
+    print(f"Answer: {result['result']}")
 
     print("-" * 30)
 
@@ -63,7 +62,7 @@ if __name__ == "__main__":
     # response_2 = get_response(question_2, qa_chain)
     # print(f"Answer: {response_2}")
     print("--- Source Chunks Used ---")
-    for i, doc in enumerate(response['source_documents']):
+    for i, doc in enumerate(result['source_documents']):
         print(f"--- Chunk {i+1} ---\n")
         print(doc.page_content)
         print("\n")


### PR DESCRIPTION
## Summary
- Return full RetrievalQA chain output in `get_response`
- Update main execution to print answer and iterate over source documents from full result

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a24c02bb9c8328aee3f6751fbd3385