### PR TITLE
Add text chunking and document parsing utilities

### DIFF
--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import List
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+
+def split_text(
+    text: str,
+    chunk_size: int = 1000,
+    chunk_overlap: int = 200,
+    **kwargs,
+) -> List[str]:
+    """Split text into smaller chunks.
+
+    This utility wraps :class:`~langchain.text_splitter.RecursiveCharacterTextSplitter`
+    allowing callers to configure the chunk size and overlap used for splitting
+    arbitrary text into smaller pieces.
+
+    Parameters
+    ----------
+    text: str
+        The raw text to split.
+    chunk_size: int, optional
+        Maximum size (in characters) for each chunk. Defaults to ``1000``.
+    chunk_overlap: int, optional
+        Number of characters to overlap between consecutive chunks. Defaults to
+        ``200``.
+    **kwargs:
+        Additional keyword arguments forwarded to
+        :class:`RecursiveCharacterTextSplitter`.
+
+    Returns
+    -------
+    List[str]
+        A list of text chunks.
+    """
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size, chunk_overlap=chunk_overlap, **kwargs
+    )
+    return splitter.split_text(text)

--- a/src/ingestion/data_loader.py
+++ b/src/ingestion/data_loader.py
@@ -1,39 +1,55 @@
+from __future__ import annotations
+
 import os
-from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.document_loaders import TextLoader
+from pathlib import Path
+from typing import Optional
+
 from langchain.embeddings import HuggingFaceEmbeddings
 from langchain.vectorstores import FAISS
 
-def create_vector_db():
-    """
-    Reads text from a file, chunks it, creates embeddings,
-    and stores them in a FAISS vector database.
-    """
-    # 1. Load the document
-    loader = TextLoader("data/processed_text/california_llc_guide.txt")
-    documents = loader.load()
-    print(f"Loaded {len(documents)} document.")
+from .chunker import split_text
+from .document_parser import load_document
 
-    # 2. Split the document into chunks
-    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=150)
-    chunks = text_splitter.split_documents(documents)
-    print(f"Split document into {len(chunks)} chunks.")
 
-    # 3. Initialize the embedding model
+def create_vector_db(
+    file_path: str | Path = "data/processed_text/california_llc_guide.txt",
+    chunk_size: int = 1000,
+    chunk_overlap: int = 150,
+    save_dir: str | Path = "data/knowledge_base/faiss_index_california",
+) -> FAISS:
+    """Create a FAISS vector store from a document.
+
+    Parameters
+    ----------
+    file_path: str or Path
+        Path to the source document. Supported formats include plain text and
+        HTML.
+    chunk_size: int, optional
+        Size of text chunks produced by the splitter. Defaults to ``1000``.
+    chunk_overlap: int, optional
+        Overlap between consecutive chunks. Defaults to ``150``.
+    save_dir: str or Path, optional
+        Directory where the vector store will be saved.
+    """
+
+    # Load and chunk the document
+    text = load_document(file_path)
+    chunks = split_text(text, chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+
+    # Initialize the embedding model
     model_name = "sentence-transformers/all-MiniLM-L6-v2"
-    model_kwargs = {'device': 'cpu'}
+    model_kwargs = {"device": "cpu"}
     embeddings = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kwargs)
-    print("Embeddings model loaded.")
 
-    # 4. Create the FAISS vector store
-    vector_store = FAISS.from_documents(chunks, embeddings)
-    print("Vector store created.")
+    # Create the FAISS vector store
+    vector_store = FAISS.from_texts(chunks, embeddings)
 
-    # 5. Save the vector store locally
-    if not os.path.exists("data/knowledge_base"):
-        os.makedirs("data/knowledge_base")
-    vector_store.save_local("data/knowledge_base/faiss_index_california")
-    print("Vector store saved locally at data/knowledge_base/faiss_index_california")
+    # Save the vector store
+    save_path = Path(save_dir)
+    os.makedirs(save_path.parent, exist_ok=True)
+    vector_store.save_local(str(save_path))
+    return vector_store
 
-if __name__ == "__main__":
+
+if __name__ == "__main__":  # pragma: no cover
     create_vector_db()

--- a/src/ingestion/document_parser.py
+++ b/src/ingestion/document_parser.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from bs4 import BeautifulSoup
+
+
+def normalize_text(text: str) -> str:
+    """Normalize whitespace in a block of text."""
+    lines = [line.strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+def load_plain_text(path: str | Path) -> str:
+    """Load and normalize text from a plain ``.txt`` file."""
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+    return normalize_text(text)
+
+
+def load_html(path: str | Path) -> str:
+    """Load an HTML file and return its normalized text content."""
+    with open(path, "r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
+    text = soup.get_text(separator="\n")
+    return normalize_text(text)
+
+
+def load_document(path: str | Path) -> str:
+    """Load a document based on its file extension."""
+    path = Path(path)
+    loader: Callable[[str | Path], str]
+    if path.suffix.lower() in {".txt"}:
+        loader = load_plain_text
+    elif path.suffix.lower() in {".html", ".htm"}:
+        loader = load_html
+    else:
+        raise ValueError(f"Unsupported file type: {path.suffix}")
+    return loader(path)

--- a/tests/ingestion/test_parser.py
+++ b/tests/ingestion/test_parser.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from ingestion.chunker import split_text
+from ingestion.document_parser import load_html, load_plain_text
+
+
+def test_split_text_basic():
+    text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * 10
+    chunks = split_text(text, chunk_size=50, chunk_overlap=0)
+    assert all(len(chunk) <= 50 for chunk in chunks)
+    assert sum(len(c) for c in chunks) >= len(text) - 50  # allow for final partial chunk
+
+
+def test_load_plain_text(tmp_path: Path):
+    file = tmp_path / "sample.txt"
+    file.write_text("line1\n\n line2  \n")
+    assert load_plain_text(file) == "line1\nline2"
+
+
+def test_load_html(tmp_path: Path):
+    file = tmp_path / "sample.html"
+    file.write_text("<html><body><p>Hello</p><div>World</div></body></html>")
+    assert load_html(file) == "Hello\nWorld"


### PR DESCRIPTION
## Summary
- implement configurable `split_text` utility using `RecursiveCharacterTextSplitter`
- add plain-text and HTML document loaders with normalization helpers
- refactor vector DB loader to reuse chunker and parsers
- provide tests for the new ingestion utilities

## Testing
- `pytest tests/ingestion/test_parser.py -q` *(fails: ModuleNotFoundError: No module named 'langchain')*
- `pip install langchain==0.1.20` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a24bd77be48328bebb01a238acf5a4