### PR TITLE
Add core LangChain dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
 requests
 beautifulsoup4
-lxml 
+lxml
 python-dotenv
+langchain
+langchain-openai
+faiss-cpu
+sentence-transformers
+pytest


### PR DESCRIPTION
## Summary
- include langchain, langchain-openai, faiss-cpu, sentence-transformers, and pytest in requirements.txt
- ensure requirements cover modules imported in chatbot and ingestion modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a24be0d7a0832892e5e919fe2a3035