### PR TITLE
Add state-based knowledge selection to chatbot QA chain

### DIFF
--- a/src/chatbot/bot.py
+++ b/src/chatbot/bot.py
@@ -5,10 +5,23 @@ from langchain.vectorstores import FAISS
 from langchain_openai import ChatOpenAI
 from langchain.chains import RetrievalQA
 
-def create_qa_chain():
+
+def infer_state_from_query(query: str) -> str:
+    """Naively infer a state slug from the user's query.
+
+    Currently only supports California. If no state is found, defaults to
+    "california".
     """
-    Loads the vector store and sets up the Question-Answering chain using OpenAI.
-    """
+    query_lower = query.lower()
+    if "california" in query_lower or "ca" in query_lower:
+        return "california"
+    # Default/fallback
+    return "california"
+
+
+def create_qa_chain(state_slug: str = "california"):
+    """Load the vector store and set up the QA chain for a given state."""
+
     # Load environment variables from .env file
     load_dotenv()
 
@@ -16,14 +29,16 @@ def create_qa_chain():
     if not os.getenv("OPENAI_API_KEY"):
         raise ValueError("OpenAI API key not found. Please set it in your .env file.")
 
-    # 1. Load the local vector store
-    db_path = "data/knowledge_base/faiss_index_california"
+    # 1. Load the local vector store for the selected state
+    db_path = f"data/knowledge_base/faiss_index_{state_slug}"
     model_name = "sentence-transformers/all-MiniLM-L6-v2"
-    model_kwargs = {'device': 'cpu'}
+    model_kwargs = {"device": "cpu"}
     embeddings = HuggingFaceEmbeddings(model_name=model_name, model_kwargs=model_kwargs)
-    
+
     # allow_dangerous_deserialization is needed for loading local FAISS indexes
-    vector_store = FAISS.load_local(db_path, embeddings, allow_dangerous_deserialization=True)
+    vector_store = FAISS.load_local(
+        db_path, embeddings, allow_dangerous_deserialization=True
+    )
     print("Vector store loaded successfully.")
 
     # 2. Set up the LLM from OpenAI
@@ -34,24 +49,25 @@ def create_qa_chain():
     qa_chain = RetrievalQA.from_chain_type(
         llm=llm,
         chain_type="stuff",
-        retriever=vector_store.as_retriever(search_kwargs={'k': 3}),
-        return_source_documents=True
+        retriever=vector_store.as_retriever(search_kwargs={"k": 3}),
+        return_source_documents=True,
     )
     print("QA chain created.")
     return qa_chain
 
+
 def get_response(query, chain):
-    """
-    Gets a response from the QA chain for a given query.
-    """
-    result = chain({'query': query})
-    return result['result']
+    """Gets a response from the QA chain for a given query."""
+    result = chain({"query": query})
+    return result["result"]
+
 
 if __name__ == "__main__":
-    qa_chain = create_qa_chain()
-
     question = "I want to operate under a fictitious business name"
     print(f"\nQuery: {question}")
+
+    slug = infer_state_from_query(question)
+    qa_chain = create_qa_chain(slug)
 
     response = get_response(question, qa_chain)
     print(f"Answer: {response}")
@@ -63,7 +79,8 @@ if __name__ == "__main__":
     # response_2 = get_response(question_2, qa_chain)
     # print(f"Answer: {response_2}")
     print("--- Source Chunks Used ---")
-    for i, doc in enumerate(response['source_documents']):
+    for i, doc in enumerate(response["source_documents"]):
         print(f"--- Chunk {i+1} ---\n")
         print(doc.page_content)
         print("\n")
+


### PR DESCRIPTION
## Summary
- allow QA chain creation to accept a state slug and load the corresponding FAISS index
- add naive state inference helper to choose an index based on a user's query
- update example usage to infer state before building the chain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a24bfc7b8083288d9d2b2f4c91314a